### PR TITLE
Using episode title from metadata as filename when available

### DIFF
--- a/podcast_archiver.py
+++ b/podcast_archiver.py
@@ -151,7 +151,7 @@ class PodcastArchiver:
 
         return filename
 
-    def linkToTargetFilename(self, link, must_have_ext=False):
+    def linkToTargetFilename(self, link, title='', must_have_ext=False):
 
         # Remove HTTP GET parameters from filename by parsing URL properly
         linkpath = urlparse(link).path
@@ -161,15 +161,18 @@ class PodcastArchiver:
         if must_have_ext and not ext:
             return None
 
+        if title:
+            basename = title + ext
+
         # If requested, slugify the filename
         if self.slugify:
             basename = PodcastArchiver.slugifyString(basename)
             self._feed_title = PodcastArchiver.slugifyString(self._feed_title)
         else:
-            basename.replace(path.pathsep, '_')
-            basename.replace(path.sep, '_')
-            self._feed_title.replace(path.pathsep, '_')
-            self._feed_title.replace(path.sep, '_')
+            basename = basename.replace(path.pathsep, '_')
+            basename = basename.replace(path.sep, '_')
+            self._feed_title = self._feed_title.replace(path.pathsep, '_')
+            self._feed_title = self._feed_title.replace(path.sep, '_')
 
         # Generate local path and check for existence
         if self.subdirs:
@@ -271,7 +274,7 @@ class PodcastArchiver:
             if self.update:
                 for index, episode_dict in enumerate(linklist):
                     link = episode_dict['url']
-                    filename = self.linkToTargetFilename(link)
+                    filename = self.linkToTargetFilename(link, episode_dict.get('title'))
 
                     if path.isfile(filename):
                         del(linklist[index:])
@@ -325,7 +328,7 @@ class PodcastArchiver:
                         print("\t * %10s: %s" % (key, episode_dict[key]))
 
             # Check existence once ...
-            filename = self.linkToTargetFilename(link)
+            filename = self.linkToTargetFilename(link, episode_dict.get('title'))
 
             if self.verbose > 1:
                 print("\tLocal filename:", filename)
@@ -343,7 +346,7 @@ class PodcastArchiver:
                     # Check existence another time, with resolved link
                     link = response.geturl()
                     total_size = int(response.getheader('content-length', '0'))
-                    new_filename = self.linkToTargetFilename(link, must_have_ext=True)
+                    new_filename = self.linkToTargetFilename(link, episode_dict.get('title'), must_have_ext=True)
 
                     if new_filename and new_filename != filename:
                         filename = new_filename


### PR DESCRIPTION
Hi!

I've made your script download each podcast episode using its title instead of the (mostly ugly) filename that podcast hostings use.

Feel free to make a code review and, if you like, accept this pull request. I think these changes closes #21.

Thank you for your work. This script saved me a lot of time.

Kind regards.