### PR TITLE
Support episode name on filenames, arg -n and loop -l

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.opml
 *.txt
+.DS_Store
+.vscode/

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Before downloading any episode the function first fetches all available pages of
 * `-p` / `--progress`: Show a progress bar for episode downloads. Can be used in conjunction with `--verbose` (see above).
 * `-S` / `--slugify`: Clean all folders and filename of potentially weird characters that might cause trouble with one or another target filesystem. The character set boils down to about: alphanumeric characters (both upper and lower case), dashes, and underscores, with unicode characters being normalized according to [Compatibility Decomposition](#excursion-unicode-normalization-in-slugify).
 * '`-m <number_of_episodes>`', `--max-episodes=<number_of_episodes>`: Only download the given `<number_of_episodes>` per podcast feed. Useful if you don't really need the entire backlog. Keep in mind that with subsequent executions with new episodes appearing, Podcast Archiver will currently *not* remove previous episodes. Therefore the number of episodes on disk will increase (actually by a maximum of `<number_of_episodes>`) when new episodes start coming up in the feed, and the Archiver is run again.
+* '`-n <name_of_episodes>`', `--name-episodes`: Adds Podcats and Episodes names to the downloaded files. Following the format: Podcast_Name - [Episode_Name]. *Attention* when used in conjunction with -S(slugify) argument it will remove [ ] from episode name.
+
 
 ### Full-fledged example
 ```

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Before downloading any episode the function first fetches all available pages of
 * `-S` / `--slugify`: Clean all folders and filename of potentially weird characters that might cause trouble with one or another target filesystem. The character set boils down to about: alphanumeric characters (both upper and lower case), dashes, and underscores, with unicode characters being normalized according to [Compatibility Decomposition](#excursion-unicode-normalization-in-slugify).
 * '`-m <number_of_episodes>`', `--max-episodes=<number_of_episodes>`: Only download the given `<number_of_episodes>` per podcast feed. Useful if you don't really need the entire backlog. Keep in mind that with subsequent executions with new episodes appearing, Podcast Archiver will currently *not* remove previous episodes. Therefore the number of episodes on disk will increase (actually by a maximum of `<number_of_episodes>`) when new episodes start coming up in the feed, and the Archiver is run again.
 * '`-n <name_of_episodes>`', `--name-episodes`: Adds Podcats and Episodes names to the downloaded files. Following the format: Podcast_Name - [Episode_Name]. *Attention* when used in conjunction with -S(slugify) argument it will remove [ ] from episode name.
+* '`-l <interval_in_seconds>`', `--loop`: Runs on infinite loop checking for new episodes ever X seconds. iex.: -l 300 would check for new episodes every 5 minutes.
 
 
 ### Full-fledged example

--- a/podcast_archiver.py
+++ b/podcast_archiver.py
@@ -37,7 +37,9 @@ from urllib.parse import urlparse
 import unicodedata
 import re
 import xml.etree.ElementTree as etree
-
+import time
+from datetime import datetime as dt
+import datetime
 
 class writeable_dir(argparse.Action):
 
@@ -50,6 +52,27 @@ class writeable_dir(argparse.Action):
         else:
             raise ArgumentTypeError("%s is not a writeable dir" % prospective_dir)
 
+class scheduler:
+    """Pooler scheduler"""
+
+    def __init__(self, interval):
+        self.interval = interval
+        self.timeIsUp = True
+        self._tick = time.time()
+        self.nextRun = None
+
+    def __call__(self):
+        return self._isItTime()
+
+    def _isItTime(self):
+        self.nextRun  = dt.fromtimestamp(time.time() + self.interval).strftime('%Y-%m-%d %H:%M:%S')
+        if (self.timeIsUp) or (time.time() - self.interval > self._tick):
+            self._tick =  time.time()
+            self.timeIsUp = False
+            return True
+
+    def sleeper(self):
+        time.sleep(int(self.interval) - ((time.time() - self._tick) % int(self.interval)))
 
 class PodcastArchiver:
 
@@ -72,11 +95,15 @@ class PodcastArchiver:
 
     feedlist = []
 
-    def __init__(self):
+    def __init__(self,args):
 
         feedparser.USER_AGENT = self._userAgent
+        self._addArguments(args)
 
-    def addArguments(self, args):
+        if self.scheduler:
+            self.scheduler = scheduler(self.scheduler)
+
+    def _addArguments(self, args):
 
         # if type(args) is argparse.ArgumentParser:
         #     args = parser.parse_args()
@@ -100,6 +127,7 @@ class PodcastArchiver:
         self.slugify = args.slugify
         self.maximumEpisodes = args.max_episodes or None
         self.nameEpisodes = args.name_episodes or False
+        self.scheduler = args.loop or False
 
         if self.verbose > 1:
             print("Verbose level: ", self.verbose)
@@ -155,8 +183,11 @@ class PodcastArchiver:
     def linkToTargetFilename(self, link, must_have_ext=False):
 
         # Remove HTTP GET parameters from filename by parsing URL properly
-        linkpath = urlparse(link).path
-        basename = path.basename(linkpath)
+        if self.nameEpisodes:
+            basename = link
+        else:
+            linkpath = urlparse(link).path
+            basename = path.basename(linkpath)
 
         _, ext = path.splitext(basename)
         if must_have_ext and not ext:
@@ -280,7 +311,7 @@ class PodcastArchiver:
             if self.update:
                 for index, episode_dict in enumerate(linklist):
                     link = episode_dict['url']
-                    if self.nameEpisodes is not None:
+                    if self.nameEpisodes is not False:
                         filename = self.linkToTargetFilename(episode_dict['filename'])
                     else:
                         filename = self.linkToTargetFilename(link)
@@ -309,7 +340,6 @@ class PodcastArchiver:
 
         return linklist
 
-
     def downloadPodcastFiles(self, linklist):
         if linklist is None or self._feed_title is None:
             return
@@ -337,7 +367,7 @@ class PodcastArchiver:
                         print("\t * %10s: %s" % (key, episode_dict[key]))
 
             # Check existence once ...
-            if self.nameEpisodes is not None:
+            if self.nameEpisodes:
                 filename = self.linkToTargetFilename(episode_dict['filename'])
             else:
                 filename = self.linkToTargetFilename(link)
@@ -358,7 +388,7 @@ class PodcastArchiver:
                     # Check existence another time, with resolved link
                     link = response.geturl()
                     total_size = int(response.getheader('content-length', '0'))
-                    if self.nameEpisodes is not None:
+                    if self.nameEpisodes:
                         new_filename = self.linkToTargetFilename(episode_dict['filename'], must_have_ext=True)
                     else:
                         new_filename = self.linkToTargetFilename(link, must_have_ext=True)
@@ -444,12 +474,24 @@ if __name__ == "__main__":
         parser.add_argument('-n', '--name-episodes', action='store_true',
                             help='''Adds Podcats and Episodes names to the downloaded files.
                                    Following the format: Podcast_Name - [Episode_Name]''')
+        parser.add_argument('-l', '--loop', type=int,
+                            help='''Runs on infinite loop checking for new episodes ever X seconds. Iex.: -l 300
+                            would check for new episodes every 5 minutes.''')
 
         args = parser.parse_args()
+        pa = PodcastArchiver(args)
+    
+        if pa.scheduler:
+            print('\n### Podcast Archiver ############################################################')
+            while True:
+                if pa.scheduler():
+                    pa.processFeeds()
+                else:
+                    print(f"\n*** Next Run: --> {pa.scheduler.nextRun}, sleeping for {datetime.timedelta(seconds=pa.scheduler.interval)} #####################")
+                    pa.scheduler.sleeper()
+        else:
+            pa.processFeeds()
 
-        pa = PodcastArchiver()
-        pa.addArguments(args)
-        pa.processFeeds()
     except KeyboardInterrupt:
         sys.exit('\nERROR: Interrupted by user')
     except FileNotFoundError as error:


### PR DESCRIPTION
Hi Jan,

Awesome little project you have here. I forked it to include Episode Name support on filenames, since that made more sense in my workflow. I also added an option called --loop  that allows you to run the tool on an infinite loop.

The idea with loop is to move it next to a docker container and be run as a podcast watcher/archiver.

Both features are entirely optional and can be enabled by using -n and -l argument.

That being said I'm PRing back to you. Merge if you feel like so!

Thanks for the project!